### PR TITLE
Fix: '/' in excluded folders now matches every file

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -313,7 +313,9 @@ export async function handleAutoGenerateUid(plugin: UIDGenerator, file: TFile | 
 	// Check exclusions
 	if (plugin.settings.autoGenerationExclusions.some(ex => {
 		const normEx = normalizePath(ex.trim());
-		return normEx && (normalizedPath.startsWith(normEx + '/') || normalizedPath === normEx);
+		// '/' means the vault root — matches every file, consistent with
+		// how the vault root is treated in getFilesInFolder / clearUIDsInFolder.
+		return normEx && (normEx === '/' || normalizedPath.startsWith(normEx + '/') || normalizedPath === normEx);
 	})) {
 		return; // Excluded
 	}
@@ -367,7 +369,9 @@ export async function handleAddMissingUidsInScope(plugin: UIDGenerator): Promise
 			// 1. Check exclusions
 			if (plugin.settings.autoGenerationExclusions.some(ex => {
 				const normEx = normalizePath(ex.trim());
-				return normEx && (normalizedPath.startsWith(normEx + '/') || normalizedPath === normEx);
+				// '/' means the vault root — matches every file, consistent with
+				// how the vault root is treated in getFilesInFolder / clearUIDsInFolder.
+				return normEx && (normEx === '/' || normalizedPath.startsWith(normEx + '/') || normalizedPath === normEx);
 			})) {
 				isInScope = false; // Excluded
 			}


### PR DESCRIPTION
## Summary

Adding the vault root (`/`) to **Excluded folders** in the Automatic UID Generation settings currently has no effect: files still get UIDs generated.

## Root cause

In `src/commands.ts`, both `handleAutoGenerateUid` and `handleAddMissingUidsInScope` check exclusions with:

```ts
const normEx = normalizePath(ex.trim());
return normEx && (normalizedPath.startsWith(normEx + '/') || normalizedPath === normEx);
```

When the user selects the vault root from the folder picker, `ex === '/'` and `normalizePath('/')` returns `'/'`. File paths in Obsidian never start with a slash (`note.md`, `sub/note.md`), so:

- `path.startsWith('/' + '/')` — matches nothing (no path starts with `//`)
- `path === '/'` — matches nothing (no file path equals `/`)

Result: the `/` exclusion silently never fires.

## Fix

Treat `normEx === '/'` as "matches every file in the vault". This is consistent with how the same file already interprets the vault root in `getFilesInFolder` (commands.ts:134) and `clearUIDsInFolder` (commands.ts:274):

```ts
let isInside = (targetPath === '/') ? file.path !== '/' : file.path.startsWith(targetPath + '/');
```

The fix applies the same convention to both exclusion checks. A short comment documents the intent so it doesn't drift again.

## Test plan

- [x] Build succeeds (`npm run build`)
- [ ] In a vault with `autoGenerationExclusions: ["/"]` and `autoGenerateUid: true`:
  - Opening/creating a note at the root no longer adds a UID
  - "Generate missing uids now" skips every file (reports all as out-of-scope/excluded)
- [ ] Regression check: exclusions on regular subfolders (e.g. `Templates`) still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)